### PR TITLE
Fix for fetching tree files that have slashes in URL

### DIFF
--- a/src/coffee/github.coffee
+++ b/src/coffee/github.coffee
@@ -72,7 +72,7 @@ class window.Github
       self.ref = $('.commit-id:last').text()
 
     else if self.page is 'tree'
-      self.ref = $('.file-navigation .select-menu-button:first').attr('data-ref')
+      self.ref = $('.file-navigation .repo-root a:first').attr('data-branch')
 
     else
       # no coverage overlay

--- a/src/coffee/github.coffee
+++ b/src/coffee/github.coffee
@@ -72,7 +72,7 @@ class window.Github
       self.ref = $('.commit-id:last').text()
 
     else if self.page is 'tree'
-      self.ref = $('.file-wrap a.js-directory-link:first').attr('href').split('/')[4]
+      self.ref = $('.file-navigation .select-menu-button:first').attr('data-ref')
 
     else
       # no coverage overlay


### PR DESCRIPTION
Fetch the full branch name from the data-ref of the select on the page, since parsing based on slashes is unreliable.