### PR TITLE
Add support for Bitbucket's new PR Url

### DIFF
--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -448,7 +448,7 @@ window.Bitbucket = (function(superClass) {
       return href[6].split('?')[0];
     } else if (this.page === 'commits') {
       return href[6].split('?')[0];
-    } else if (this.page === 'pull-request') {
+    } else if (this.page === 'pull-request' || this.page === 'pull-requests' ) {
       return (ref = $('.view-file:first').attr('href')) != null ? ref.split('/')[4] : void 0;
     }
     return false;


### PR DESCRIPTION
I added "pull-requests" as a possible PR match, but left "pull-request"
as well, to maintain backwards compatibility. Fixes #12 