### PR TITLE
fix handling of untracked files

### DIFF
--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -411,7 +411,7 @@ window.Github = (function(superClass) {
             if (self.settings.overlay && ((ref8 = self.page) === 'blob' || ref8 === 'blame')) {
               return button.trigger('click');
             }
-          } else if (file_data.ignored === true) {
+          } else if ((file_data != null) && file_data.ignored === true) {
             return file.find('.btn.codecov').attr('aria-label', 'File ignored').text('Not covered');
           } else {
             return file.find('.btn.codecov').attr('aria-label', 'File not reported to Codecov').text('Not covered');

--- a/src/coffee/github.coffee
+++ b/src/coffee/github.coffee
@@ -193,7 +193,7 @@ class window.Github extends Codecov
             # toggle blob/blame
             if self.settings.overlay and self.page in ['blob', 'blame']
               button.trigger('click')
-          else if file_data.ignored is true  # v3
+          else if file_data? and file_data.ignored is true  # v3
             file
               .find('.btn.codecov')
               .attr('aria-label', 'File ignored')


### PR DESCRIPTION
This closes #28 and gets all the tests in `test/github/test_commit.js` to pass.

This bug was introduced here: https://github.com/codecov/browser-extension/commit/2feb14278dc400e25cb9909579d0ad15b519a56d#diff-37dd5cc965836ba35bb55fe7ba672177R196