### PR TITLE
Fix "ReferenceError: $ is not defined"

### DIFF
--- a/src/chrome/listener.js
+++ b/src/chrome/listener.js
@@ -1,11 +1,3 @@
-if ($ == null || $ == undefined) {
-  document.addEventListener("pjax:success", function(){
-    window.postMessage({type:"codecov"},"*");
-  });
-} else {
-  $(function(){
-    $(document).on('pjax:success', function(){
-      window.postMessage({type:"codecov"},"*");
-    });
-  });
-}
+document.addEventListener("pjax:success", function(){
+  window.postMessage({type:"codecov"}, "*");
+});


### PR DESCRIPTION
This browser extension didn't work on Chromium 53.0.2785.143.

![codecov](https://user-images.githubusercontent.com/10341686/37512094-14c246c0-293c-11e8-9c07-58a04af797cd.png)
