### PR TITLE
Removed jQuery usage in listener, fixes #55

### DIFF
--- a/src/chrome/listener.js
+++ b/src/chrome/listener.js
@@ -1,11 +1,3 @@
-if ($ == null || $ == undefined) {
-  document.addEventListener("pjax:success", function(){
-    window.postMessage({type:"codecov"},"*");
-  });
-} else {
-  $(function(){
-    $(document).on('pjax:success', function(){
-      window.postMessage({type:"codecov"},"*");
-    });
-  });
-}
+document.addEventListener("pjax:success", function(){
+  window.postMessage({type:"codecov"},"*");
+});


### PR DESCRIPTION
This PR fixes #55 by removing jQuery usage entirely in `listener.js`.

Note: I believe using jQuery is not necessary as [addEventListener](https://caniuse.com/#feat=addeventlistener) and [postMessage](https://caniuse.com/#feat=x-doc-messaging) are widely supported now (especially this is Chrome-only here).
